### PR TITLE
fix: support feat! breaking change notation in semantic-release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,18 +1,13 @@
 export default {
   branches: [{ name: "v1", channel: "v1" }, "main"],
   plugins: [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        preset: "conventionalcommits", // 👈 Add this
+    ["@semantic-release/commit-analyzer", {
+      parserOpts: {
+        headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+        breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+        headerCorrespondence: ["type", "scope", "subject"],
       },
-    ],
-    [
-      "@semantic-release/release-notes-generator",
-      {
-        preset: "conventionalcommits", // 👈 Add this for consistent notes
-      },
-    ],
+    }],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
Add parserOpts to commit-analyzer so feat!: and feat(scope)!: are recognized as breaking changes and trigger a major bump. Angular preset v8 headerPattern lacks ! support by default.